### PR TITLE
[BUGFIX] Fix cms-core version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"GPL-2.0+"
 	],
 	"require": {
-		"typo3/cms-core": "^6.2 || ^7.6 || 8.7 "
+		"typo3/cms-core": "^6.2 || ^7.6 || ^8.7 "
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Installation fails on TYPO3 8.7.4 with the original contraint.