### PR TITLE
[TASK] Add support for TYPO3 9 LTS to retrieve deprecation log file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Visit my `Amazon whishlist <https://www.amazon.de/registry/wishlist/8F573K08TSDG
 
 Requirements
 ------------
-- TYPO3 CMS 6.2, 7.6, 8.7
+- TYPO3 CMS 6.2, 7.6, 8.7, 9.5
 
 Installation
 ------------

--- a/Resources/Private/Templates/Report.html
+++ b/Resources/Private/Templates/Report.html
@@ -1,6 +1,5 @@
 <html
 	xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-	xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
 	data-namespace-typo3-fluid="true">
 <p class="lead">{f:translate(key:'report.description',extensionName:'deprecationloganalyzer')}</p>
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"GPL-2.0+"
 	],
 	"require": {
-		"typo3/cms-core": "^6.2 || ^7.6 || ^8.7"
+		"typo3/cms-core": "^6.2 || ^7.6 || ^8.7 || ^9.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'mail@ringer.it',
     'constraints' => [
         'depends' => [
-            'typo3' => '6.2.0-8.7.99',
+            'typo3' => '6.2.0-9.5.99',
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,12 +3,10 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-if (TYPO3_MODE === 'BE') {
-    // Registering the report
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['reports']['tx_deprecationloganalyzer']['index'] = [
-        'title' => 'LLL:EXT:deprecationloganalyzer/Resources/Private/Language/locallang.xml:report.title',
-        'description' => 'LLL:EXT:deprecationloganalyzer/Resources/Private/Language/locallang.xml:report.description',
-        'report' => \GeorgRinger\Deprecationloganalyzer\Report::class,
-        'icon' => 'EXT:deprecationloganalyzer/Resources/Public/Icons/report_icon.png'
-    ];
-}
+// Registering the report
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['reports']['tx_deprecationloganalyzer']['index'] = [
+    'title' => 'LLL:EXT:deprecationloganalyzer/Resources/Private/Language/locallang.xml:report.title',
+    'description' => 'LLL:EXT:deprecationloganalyzer/Resources/Private/Language/locallang.xml:report.description',
+    'report' => \GeorgRinger\Deprecationloganalyzer\Report::class,
+    'icon' => 'EXT:deprecationloganalyzer/Resources/Public/Icons/report_icon.png'
+];


### PR DESCRIPTION
- update misc. extension files to allow TYPO3 9 LTS
- update README
- remove ext_tables TYPO3_MODE as suggested in the
  official docs.
- remove superfluous fluid namespace declaration
- add support to retrieve deprecationLog file if TYPO3 version
  is >= 9.0

Related: #4